### PR TITLE
Develop command params

### DIFF
--- a/src/main/java/command/AddCommand.java
+++ b/src/main/java/command/AddCommand.java
@@ -1,5 +1,6 @@
 package command;
 
+import parser.CommandParams;
 import task.TaskList;
 import ui.Ui;
 import storage.Storage;
@@ -12,24 +13,15 @@ import exception.DukeException;
  * Responses with the result.
  */
 public class AddCommand extends Command {
-    private String description;
-    private String ddl;
-    private String timePiece;
 
     /**
      * Constructs an <code>AddCommand</code> object
      * with all components of the added task.
      *
-     * @param commandType The commandType of the added task.
-     * @param description The description of the added task.
-     * @param ddl The due of the added task(if applicable).
-     * @param timePiece The time period of the added task.
+     * @param commandParams parameters used to invoke the command.
      */
-    public AddCommand(String commandType, String description, String ddl, String timePiece) {
-        super(commandType);
-        this.description = description;
-        this.ddl = ddl;
-        this.timePiece = timePiece;
+    public AddCommand(CommandParams commandParams) {
+        super(commandParams);
     }
 
     /**
@@ -43,16 +35,21 @@ public class AddCommand extends Command {
      * @throws DukeException If exceptions occur when adding tasks or updating storage.
      */
     @Override
-    public void execute(TaskList tasks, Ui ui, Storage storage) throws DukeException{
-        switch (super.commandType) {
+    public void execute(TaskList tasks, Ui ui, Storage storage) throws DukeException {
+        if (commandParams.getMainParam() == null) {
+            throw new DukeException("☹ OOPS!!! The description of a task cannot be empty.");
+        }
+        switch (commandParams.getCommandType()) {
             case "todo":
-                tasks.addToDo(description);
+                tasks.addToDo(commandParams.getMainParam());
                 break;
             case "deadline":
-                tasks.addDeadline(description, ddl);
+                tasks.addDeadline(commandParams.getMainParam(), commandParams.getParam("by"));
                 break;
             case "event":
-                tasks.addEvent(description, timePiece);
+                tasks.addEvent(commandParams.getMainParam(),
+                        commandParams.getParam("start"),
+                        commandParams.getParam("end"));
                 break;
         }
         storage.update(tasks.toStorageStrings());

--- a/src/main/java/command/Command.java
+++ b/src/main/java/command/Command.java
@@ -1,5 +1,6 @@
 package command;
 
+import parser.CommandParams;
 import task.TaskList;
 import ui.Ui;
 import storage.Storage;
@@ -9,15 +10,15 @@ import storage.Storage;
  * Works as a parent class of more specified command classes in the package.
  */
 public class Command {
-    protected String commandType;
+    protected CommandParams commandParams;
 
     /**
      * Constructs a <code>Command</code> object with commandType.
      *
-     * @param commandType CommandType of the constructed command.
+     * @param commandParams parameters used to invoke the command.
      */
-    protected Command(String commandType){
-        this.commandType = commandType;
+    protected Command(CommandParams commandParams){
+        this.commandParams = commandParams;
     }
 
     /**
@@ -39,7 +40,7 @@ public class Command {
      * @return The boolean indicating whether quit the loop in <code>main</code> method.
      */
     public boolean isExit() {
-        if (commandType.equals("exit")) {
+        if (commandParams.getCommandType().equals("exit")) {
             return true;
         } else {
             return false;

--- a/src/main/java/command/DeleteCommand.java
+++ b/src/main/java/command/DeleteCommand.java
@@ -31,7 +31,7 @@ public class DeleteCommand extends Command {
      * @param tasks The taskList of Duke.
      * @param ui The ui of Duke.
      * @param storage The storage of Duke.
-     * @throws DukeException If the index given is out of range.
+     * @throws DukeException If the index given is out of range, invalid, or does not exist.
      */
     @Override
     public void execute(TaskList tasks, Ui ui, Storage storage) throws DukeException {

--- a/src/main/java/command/DeleteCommand.java
+++ b/src/main/java/command/DeleteCommand.java
@@ -1,5 +1,6 @@
 package command;
 
+import parser.CommandParams;
 import task.TaskList;
 import ui.Ui;
 import storage.Storage;
@@ -11,17 +12,15 @@ import exception.DukeException;
  * Responses with the result.
  */
 public class DeleteCommand extends Command {
-    private int index;
 
     /**
      * Constructs a <code>DeleteCommand</code> object
      * given the index of the task to be deleted.
      *
-     * @param index The index of the task to be deleted.
+     * @param commandParams parameters used to invoke the command.
      */
-    public DeleteCommand(int index) {
-        super("delete");
-        this.index = index;
+    public DeleteCommand(CommandParams commandParams) {
+        super(commandParams);
     }
 
     /**
@@ -36,16 +35,22 @@ public class DeleteCommand extends Command {
      */
     @Override
     public void execute(TaskList tasks, Ui ui, Storage storage) throws DukeException {
-        String str;
+        if (commandParams.getMainParam() == null) {
+            throw new DukeException("☹ OOPS!!! I don't know which task to delete!");
+        }
+        String taskInfo;
         try {
-            str = tasks.getTaskInfo(index);
+            int index = Integer.parseInt(commandParams.getMainParam());
+            taskInfo = tasks.getTaskInfo(index);
             tasks.delete(index);
         } catch (IndexOutOfBoundsException e) {
             throw new DukeException("☹ OOPS!!! The index should be in range.");
+        } catch (NumberFormatException e) {
+            throw new DukeException("☹ OOPS!!! The index be a number.");
         }
         storage.update(tasks.toStorageStrings());
         ui.println("Noted. I've removed this task:");
-        ui.println(str);
+        ui.println(taskInfo);
         ui.println("Now you have " + tasks.getSize() + " tasks in the list.");
     }
 }

--- a/src/main/java/command/DoneCommand.java
+++ b/src/main/java/command/DoneCommand.java
@@ -31,7 +31,7 @@ public class DoneCommand extends Command {
      * @param tasks The taskList of Duke.
      * @param ui The ui of Duke.
      * @param storage The storage of Duke.
-     * @throws DukeException If the index given is out of range.
+     * @throws DukeException If the index given is out of range, invalid, or does not exist.
      */
     @Override
     public void execute(TaskList tasks, Ui ui, Storage storage) throws DukeException {

--- a/src/main/java/command/DoneCommand.java
+++ b/src/main/java/command/DoneCommand.java
@@ -1,5 +1,6 @@
 package command;
 
+import parser.CommandParams;
 import task.TaskList;
 import ui.Ui;
 import storage.Storage;
@@ -11,17 +12,15 @@ import exception.DukeException;
  * Responses with the result.
  */
 public class DoneCommand extends Command {
-    private int index;
 
     /**
      * Constructs a <code>DoneCommand</code> object
      * given the index of the task to be marked as done.
      *
-     * @param index The index of the task to be marked as done.
+     * @param commandParams parameters used to invoke the command.
      */
-    public DoneCommand(int index) {
-        super("done");
-        this.index = index;
+    public DoneCommand(CommandParams commandParams) {
+        super(commandParams);
     }
 
     /**
@@ -36,15 +35,23 @@ public class DoneCommand extends Command {
      */
     @Override
     public void execute(TaskList tasks, Ui ui, Storage storage) throws DukeException {
+        if (commandParams.getMainParam() == null) {
+            throw new DukeException("☹ OOPS!!! I don't know which task to set as done!");
+        }
+        String taskInfo;
         try {
+            int index = Integer.parseInt(commandParams.getMainParam());
             tasks.done(index);
+            taskInfo = tasks.getTaskInfo(index);
         } catch (IndexOutOfBoundsException e) {
             throw new DukeException("☹ OOPS!!! The index should be in range.");
+        } catch (NumberFormatException e) {
+            throw new DukeException("☹ OOPS!!! The index be a number.");
         }
         storage.update(tasks.toStorageStrings());
 
         ui.println("Nice! I've marked this task as done:");
-        ui.println(tasks.getTaskInfo(index));
+        ui.println(taskInfo);
     }
 
 }

--- a/src/main/java/command/ExitCommand.java
+++ b/src/main/java/command/ExitCommand.java
@@ -1,5 +1,6 @@
 package command;
 
+import parser.CommandParams;
 import task.TaskList;
 import ui.Ui;
 import storage.Storage;
@@ -12,9 +13,11 @@ import storage.Storage;
 public class ExitCommand extends Command {
     /**
      * Constructs an <code>ExitCommand</code> object.
+     *
+     * @param commandParams parameters used to invoke the command.
      */
-    public ExitCommand() {
-        super("exit");
+    public ExitCommand(CommandParams commandParams) {
+        super(commandParams);
     }
 
     /**

--- a/src/main/java/command/FindCommand.java
+++ b/src/main/java/command/FindCommand.java
@@ -1,5 +1,7 @@
 package command;
 
+import exception.DukeException;
+import parser.CommandParams;
 import task.TaskList;
 import ui.Ui;
 import storage.Storage;
@@ -12,17 +14,15 @@ import java.util.ArrayList;
  * Responses with the result.
  */
 public class FindCommand extends Command {
-    private String target;
 
     /**
      * Constructs a <code>FindCommand</code> object
      * with given searched keyword.
      *
-     * @param target The searched keyword.
+     * @param commandParams parameters used to invoke the command.
      */
-    public FindCommand(String target) {
-        super("find");
-        this.target = target;
+    public FindCommand(CommandParams commandParams) {
+        super(commandParams);
     }
 
     /**
@@ -32,10 +32,14 @@ public class FindCommand extends Command {
      * @param tasks The taskList of Duke.
      * @param ui The ui of Duke.
      * @param storage The storage of Duke.
+     * @throws DukeException if a search string was not given.
      */
     @Override
-    public void execute(TaskList tasks, Ui ui, Storage storage) {
-        ArrayList<Integer> matchedList = tasks.find(target);
+    public void execute(TaskList tasks, Ui ui, Storage storage) throws DukeException {
+        if (commandParams.getMainParam() == null) {
+            throw new DukeException("☹ OOPS!!! I don't what to find.");
+        }
+        ArrayList<Integer> matchedList = tasks.find(commandParams.getMainParam());
         if (matchedList.size() == 0) {
             ui.println("No results found.");
             return;

--- a/src/main/java/command/ListCommand.java
+++ b/src/main/java/command/ListCommand.java
@@ -1,5 +1,6 @@
 package command;
 
+import parser.CommandParams;
 import task.TaskList;
 import ui.Ui;
 import storage.Storage;
@@ -12,9 +13,11 @@ import storage.Storage;
 public class ListCommand extends Command {
     /**
      * Constructs a <code>ListCommand</code> object.
+     *
+     * @param commandParams parameters used to invoke the command.
      */
-    public ListCommand() {
-        super("list");
+    public ListCommand(CommandParams commandParams) {
+        super(commandParams);
     }
 
     /**

--- a/src/main/java/parser/CommandParams.java
+++ b/src/main/java/parser/CommandParams.java
@@ -1,0 +1,99 @@
+package parser;
+
+import exception.DukeException;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class CommandParams {
+    private Map<String, String> paramMap;
+    private String commandType;
+    private String mainParam;
+
+    /**
+     * Returns a <code>Map<String, String></code> containing all the parameters input by the user.
+     *
+     * @param fullCommand the full command input by the user, which will be parsed into parameters.
+     * @throws DukeException if the user specified a parameter twice.
+     */
+    public CommandParams(String fullCommand) throws DukeException {
+        // Split the full command at " /paramName", keeping paramName intact.
+        // Full conditions for matching require a space before the slash,
+        // and a paramName that is purely alphabetical.
+        // Matches: " /at", " /b", " /test" Ignores: "1/1", "a / b", "a/ "
+        paramMap = new HashMap<String, String>();
+        String[] tokens = fullCommand.split("(\\s+(\\/(?=[A-Za-z]+)))");
+
+        // Get commandType and mainParam first
+        String[] typeAndMainParam = tokens[0].split("(\\s+)");
+        commandType = typeAndMainParam[0];
+        if (typeAndMainParam.length == 2) { // has main param
+            mainParam = typeAndMainParam[1];
+        } else {
+            mainParam = null;
+        }
+
+        // Get all the others
+        for (int i = 1; i < tokens.length; i++) {
+            // Split the token into parameterName and parameterValue aka paramParams
+            String[] paramParams = tokens[i].split("(\\s+)", 2);
+            if (paramMap.containsKey(paramParams[0])) { // can't contain the same key twice
+                throw new DukeException(String.format("☹ OOPS!!! You specified %1$s twice!", paramParams[0]));
+            }
+
+            if (paramParams.length == 1) {
+                // parameter without value; possibly a flag (don't set to null?)
+                paramMap.put(paramParams[0], null);
+            } else {
+                paramMap.put(paramParams[0], paramParams[1]);
+            }
+        }
+    }
+
+    /**
+     * Returns the <code>commandType</code> parameter that was input by the user.
+     *
+     * @return <code>commandType</code>.
+     */
+    public String getCommandType() {
+        return commandType;
+    }
+
+    /**
+     * Returns the <code>mainParam</code> parameter that was input by the user. May be null.
+     *
+     * @return <code>mainParam</code>. May be null.
+     */
+    public String getMainParam() {
+        return mainParam;
+    }
+
+    /**
+     * Returns the value of a requested parameter. Use <code>containsParam()</code> to check
+     * for existence of an optional parameter, as this method will throw an exception if
+     * the parameter was not provided by the user; calling this method implies that the
+     * parameter must exist at the point where it was invoked. May be null.
+     *
+     * @param paramName the name of the parameter whose value to return.
+     * @return the value of the requested parameter. May be null.
+     * @throws DukeException if the parameter does not exist.
+     */
+    public String getParam(String paramName) throws DukeException {
+        if (containsParam(paramName)) {
+            return paramMap.get(paramName);
+        } else {
+            throw new DukeException(String.format("☹ OOPS!!! You need to give me a value for %1$s!", paramName));
+        }
+    }
+
+    /**
+     * Returns true if the parameter specified by <code>paramName</code> exists, and false otherwise.
+     * Used to check if an optional parameter exists, or for parameters that act as flags with no value.
+     *
+     * @param paramName the parameter whose existence to check for.
+     * @return true if the parameter specified by <code>paramName</code> exists, and false otherwise.
+     */
+    public boolean containsParam(String paramName) {
+        return paramMap.containsKey(paramName);
+    }
+}

--- a/src/main/java/parser/Parser.java
+++ b/src/main/java/parser/Parser.java
@@ -24,13 +24,13 @@ public class Parser {
      * Returns the packaged command.
      *
      * @param commandType The commandType of the command. e.g. list
-     * @param tokens Pieces of information of the command.
+     * @param commandParams Pieces of information of the command.
      * @return <code>Command</code> object.
      * @throws DukeException If user input is invalid.
      */
-    private static Command packageCommand(String commandType, String[] tokens) throws DukeException {
-        switch(commandType) {
-            case "todo":
+    private static Command packageCommand(String commandType, CommandParams commandParams) throws DukeException {
+        switch (commandType) {
+            case "todo": /*
                 if (tokens.length > 1) {
                     throw new DukeException("Please use other command to store time.");
                 } else if (tokens[0].equals("")) {
@@ -38,8 +38,9 @@ public class Parser {
                 }
                 description = tokens[0];
                 return new AddCommand(commandType, description,"","");
-
+                */
             case "deadline":
+                /*
                 if (tokens.length == 1 && !tokens[0].equals("")) {
                     throw new DukeException("☹ OOPS!!! The time of a deadline cannot be empty.");
                 } else if(tokens[0].equals("")) {
@@ -48,8 +49,9 @@ public class Parser {
                 description = tokens[0];
                 ddl = tokens[1];
                 return new AddCommand(commandType, description, ddl, "");
-
+                */
             case "event":
+                /*
                 if (tokens.length == 1 && !tokens[0].equals("")) {
                     throw new DukeException("☹ OOPS!!! The time of an event cannot be empty.");
                 } else if(tokens[0].equals("")) {
@@ -58,12 +60,18 @@ public class Parser {
                 description = tokens[0];
                 timePiece= tokens[1];
                 return new AddCommand(commandType, description, "", timePiece);
+                */
+                return new AddCommand(commandParams);
             case "list":
+                /*
                 if(!tokens[0].equals("")) {
                     throw new DukeException("☹ OOPS!!! I'm sorry, but I don't know what that means :-(");
                 }
                 return new ListCommand();
+                */
+                return new ListCommand(commandParams);
             case "done":
+                /*
                 if (tokens[0].equals("")) {
                     throw new DukeException("☹ OOPS!!! The index cannot be empty.");
                 }
@@ -73,7 +81,11 @@ public class Parser {
                     throw new DukeException("☹ OOPS!!! The index should be numerical.");
                 }
                 return new DoneCommand(index-1); // 0-based
+
+                */
+                return new DoneCommand(commandParams);
             case "delete":
+                /*
                 if (tokens[0].equals("")) {
                     throw new DukeException("☹ OOPS!!! The index cannot be empty.");
                 }
@@ -83,17 +95,24 @@ public class Parser {
                     throw new DukeException("☹ OOPS!!! The index should be numerical.");
                 }
                 return new DeleteCommand(index-1); // 0-based
+                */
+                return new DeleteCommand(commandParams);
             case "find":
+                /*
                 if(tokens[0].equals("") || tokens.length > 1) {
                     throw new DukeException("☹ OOPS!!! I don't what to find.");
                 }
                 return new FindCommand(tokens[0]);
-
+                */
+                return new FindCommand(commandParams);
             case "bye":
+                /*
                 if(!tokens[0].equals("")) {
                     throw new DukeException("☹ OOPS!!! I'm sorry, but I don't know what that means :-(");
                 }
                 return new ExitCommand();
+                */
+                return new ExitCommand(commandParams);
             default:
                 throw new DukeException("Unknown error!");
         }
@@ -111,15 +130,10 @@ public class Parser {
      */
     public static Command parse(String fullCommand) throws DukeException {
         String regex = "todo|deadline|event|list|done|bye|delete|find";
-        m = Pattern.compile(regex).matcher(fullCommand); // AddCommmand
-        if(m.find()) {
+        m = Pattern.compile(regex).matcher(fullCommand);
+        if (m.find()) {
             commandType = m.group();
-            fullCommand = m.replaceFirst("").trim();
-            String[] tokens = fullCommand.split("/by|/at");
-            for(int i = 0; i < tokens.length; i++) {
-                tokens[i] = tokens[i].trim();
-            }
-            return packageCommand(commandType, tokens);
+            return packageCommand(commandType, new CommandParams(fullCommand));
         } else {
             throw new DukeException("☹ OOPS!!! I'm sorry, but I don't know what that means :-(");
         }

--- a/src/main/java/task/Event.java
+++ b/src/main/java/task/Event.java
@@ -10,7 +10,8 @@ import java.util.Date;
  * with start and end <code>Date</code>.
  */
 public class Event extends Task {
-    private String timePiece;
+    private String startString;
+    private String endString;
     private Date start;
     private Date end;
 
@@ -19,19 +20,16 @@ public class Event extends Task {
      * The time period is then stored as <code>Date</code>.
      *
      * @param description Description of the task.
-     * @param timePiece String containing start and end time.
+     * @param startString String containing the start time.
+     * @param endString String containing the end time.
      * @throws DukeException If <code>timePiece</code> string has incorrect time format.
      */
-    public Event(String description, String timePiece) throws DukeException {
+    public Event(String description, String startString, String endString) throws DukeException {
         super(description);
-        this.timePiece = timePiece;
-        String[] tokens = timePiece.split("-");
-        if(tokens.length < 2) throw new DukeException("☹ OOPS!!! Cannot only show start or end time.");
-        for(int i = 0; i < tokens.length; i++) {
-            tokens[i] = tokens[i].trim();
-        }
-        start = TimeParser.parse(tokens[0]);
-        end = TimeParser.parse(tokens[1]);
+        this.startString = startString;
+        this.endString = endString;
+        this.start = TimeParser.parse(startString);
+        this.end = TimeParser.parse(endString);
     }
 
     /**
@@ -43,7 +41,7 @@ public class Event extends Task {
      */
     @Override
     public String toString() {
-        return "[E]" + super.toString() + " (at: " + timePiece + ")";
+        return "[E]" + super.toString() + " (at: " + startString + " - " + endString + ")";
     }
 
     /**
@@ -54,6 +52,6 @@ public class Event extends Task {
      */
     @Override
     public String toStorageString() {
-        return "E | " + super.toStorageString() + " | " + timePiece;
+        return "E | " + super.toStorageString() + " | " + startString + " | " + endString;
     }
 }

--- a/src/main/java/task/Task.java
+++ b/src/main/java/task/Task.java
@@ -1,5 +1,7 @@
 package task;
 
+import exception.DukeException;
+
 /**
  * Represents a simple task with description and status.
  * Works as a parent class of more specified task classes in the package.

--- a/src/main/java/task/TaskList.java
+++ b/src/main/java/task/TaskList.java
@@ -44,7 +44,7 @@ public class TaskList {
                     }
                     break;
                 case "E":
-                    addEvent(tokens[2], tokens[3]);
+                    addEvent(tokens[2], tokens[3], tokens[4]);
                     if(tokens[1].equals("1")) {
                         done(tasks.size() - 1);
                     }
@@ -77,11 +77,12 @@ public class TaskList {
      * Adds an event with description, start and end time into the taskList.
      *
      * @param description Description of the added event.
-     * @param timePiece Start and end time of the event.
+     * @param start the start time of the event.
+     * @param end the end time of the event.
      * @throws DukeException If an exception is thrown when constructing the new event.
      */
-    public void addEvent(String description, String timePiece) throws DukeException {
-            tasks.add(new Event(description, timePiece));
+    public void addEvent(String description, String start, String end) throws DukeException {
+            tasks.add(new Event(description, start, end));
     }
 
     /**

--- a/src/test/java/parser/CommandParamsTest.java
+++ b/src/test/java/parser/CommandParamsTest.java
@@ -1,0 +1,50 @@
+package parser;
+
+import exception.DukeException;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class CommandParamsTest {
+
+    @Test
+    public void testCorrectParamValues() {
+        CommandParams testParams = new CommandParams("name desc /a is a /b is b /c is c");
+        assertEquals(testParams.getCommandType(), "name");
+        assertEquals(testParams.getMainParam(), "desc");
+        assertEquals(testParams.getParam("a"), "is a");
+        assertEquals(testParams.getParam("b"), "is b");
+        assertEquals(testParams.getParam("c"), "is c");
+        assertTrue(testParams.containsParam("a"));
+        assertFalse(testParams.containsParam("d"));
+    }
+
+    @Test
+    public void testCorrectNullParamValues() {
+        CommandParams testParams = new CommandParams("noMainParam /a /b /c /d not null");
+        assertNull(testParams.getMainParam());
+        assertNull(testParams.getParam("a"));
+        assertNull(testParams.getParam("b"));
+        assertNull(testParams.getParam("c"));
+        assertNotNull(testParams.getParam("d"));
+    }
+
+    @Test
+    public void testParamNotFoundException() {
+        CommandParams testParams = new CommandParams("noParams");
+        try {
+            testParams.getParam("a");
+        } catch (DukeException e) {
+            assertEquals("☹ OOPS!!! You need to give me a value for a!", e.getMessage());
+        }
+    }
+
+    @Test
+    public void testDuplicateParams() {
+        try {
+            CommandParams testParams = new CommandParams("sameParams /a first /a second");
+        } catch (DukeException e) {
+            assertEquals("☹ OOPS!!! You specified a twice!", e.getMessage());
+        }
+    }
+}

--- a/src/test/java/task/EventTest.java
+++ b/src/test/java/task/EventTest.java
@@ -10,20 +10,20 @@ public class EventTest {
     @Test
     public void testStringConversion() {
         assertEquals("[E][\u2718] do the homework (at: 02/05/2019 1800 - 02/05/2019 1900)",
-                new Event("do the homework", "02/05/2019 1800 - 02/05/2019 1900").toString());
+                new Event("do the homework", "02/05/2019 1800","02/05/2019 1900").toString());
     }
 
     @Test
     public void testStorageStringConversion() {
-        assertEquals("E | 0 | do the homework | 02/05/2019 1800 - 02/05/2019 1900",
-                new Event("do the homework", "02/05/2019 1800 - 02/05/2019 1900").toStorageString());
+        assertEquals("E | 0 | do the homework | 02/05/2019 1800 | 02/05/2019 1900",
+                new Event("do the homework", "02/05/2019 1800", "02/05/2019 1900").toStorageString());
     }
 
     @Test
     public void toString_noHourInfo_exceptionThrown() {
         try {
             assertEquals("[E][\u2718] do the homework (at: 02/05/2019 - 02/05/2019)",
-                    new Event("do the homework", "02/05/2019 - 02/05/2019").toString());
+                    new Event("do the homework", "02/05/2019", "02/05/2019").toString());
             fail();
         } catch(Exception e) {
             assertEquals("☹ OOPS!!! Incorrect time format.", e.getMessage());


### PR DESCRIPTION
Added a new object `parser.CommandParams` to handle command parameters. This is an improvement over the previous method of extracting parameters (i.e. `String.split()`), as it removes complexity and extraneous error handling from developing new commands and from the `parser.Parser` object. 

The new object takes the user's full command as a string, and splits it into:
* The command type.
* The main parameter; optional.
* All other parameters, which can be specified using ` /parameterName [parameterValue]`, where a space must preceed the `/`, and the parameterName can only contain alphabets i.e. regex `[A-Za-z]`. The parameter value is optional, as there may be cases where it is used as a flag (i.e. `/force`). 

There are getter methods for all three, with "all other commands" accessing an internal `Map<String, String>`. 

Notes: 
* `getParam(paramName)` and `getMainParam()`, the methods which return parameter values, can return null, as null may be a valid value for the command. Since the requirement for these varies by command, it is the caller's responsibility to check if they are non-null.
* That being said, `getParam(paramName)` throws a `DukeException` if the parameter given by `paramName` was not given by the user.
* Use `containsParam()` if the parameter is optional, before calling `getParam()`, to avoid the exception (or just catch it, I guess). 

See the `CommandParamsTest` for some example usage. 