### PR TITLE
Refactor command object structure

### DIFF
--- a/src/main/java/Duke.java
+++ b/src/main/java/Duke.java
@@ -1,3 +1,4 @@
+import parser.CommandParams;
 import storage.Storage;
 import ui.Ui;
 import task.TaskList;
@@ -5,7 +6,9 @@ import exception.DukeException;
 import command.Command;
 import parser.Parser;
 
+import java.io.File;
 import java.text.ParseException;
+import java.util.StringJoiner;
 
 /**
  * Represents our Duke and contains the main program of Duke.
@@ -37,15 +40,14 @@ public class Duke {
      */
     public void run() {
         ui.showWelcome();
-        boolean isExit = false;
-        while (!isExit) {
+        while (true) {
             String fullCommand = ui.readCommand();
             try {
-                Command packagedCommand = Parser.parse(fullCommand);
-                packagedCommand.execute(tasks, ui, storage);
-                isExit = packagedCommand.isExit();
+                CommandParams commandParams = new CommandParams(fullCommand);
+                Command command = Parser.getCommand(commandParams.getCommandName());
+                command.execute(commandParams, tasks, ui, storage);
             } catch (DukeException e) {
-                ui.showError((DukeException) e);
+                ui.showError(e);
             }
         }
     }
@@ -53,10 +55,15 @@ public class Duke {
     /**
      * Runs the main program of the Duke.
      *
-     * @param args necessary arguments demanded by the main method.
+     * @param args additional arguments provided by the user from the command line. Currently unused.
      */
     public static void main(String[] args) {
-        new Duke(System.getProperty("user.dir") + "/data/TaskListStorage.txt").run();
+        String storageFile = new StringJoiner(File.separator)
+                .add(System.getProperty("user.dir"))
+                .add("data")
+                .add("TaskListStorage.txt")
+                .toString();
+        new Duke(storageFile).run();
     }
 
 }

--- a/src/main/java/command/AddCommand.java
+++ b/src/main/java/command/AddCommand.java
@@ -10,70 +10,91 @@ import task.TaskList;
 import task.ToDo;
 import ui.Ui;
 
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
 /**
  * Represents a specified command as AddCommand by extending the {@code Command} class.
  * Adds various specified type of tasks into the taskList. e.g event
  * Responses with the result.
  */
 public class AddCommand extends Command {
+    private static final String name = "add";
+    private static final String description = "adds a task";
+    private static final String usage = "add $description "
+            + "/[after $time|recurring $interval|tentative|start $time|end $time|by $time|needs $[time|task]";
 
-    /**
-     * Constructs an {@code AddCommand} object
-     * with all components of the added task.
-     *
-     * @param commandParams parameters used to invoke the command.
-     */
-    public AddCommand(CommandParams commandParams) {
-        super(commandParams);
+    private enum SecondaryParam {
+        AFTER("after", "make the task only doable after another task or time"),
+        RECURRING("recurring", "make the task recur at a set interval"),
+        TENTATIVE("tentative", "make the task tentative, to be confirmed at a later time"),
+        START("start", "set the starting time of the task"),
+        END("end", "set the ending time of the task"),
+        BY("by", "set the task as required to be done by a certain time"),
+        NEEDS("needs", "set the amount of time required to do the task");
+
+        private String name;
+        private String description;
+
+        SecondaryParam(String name, String description) {
+            this.name = name;
+            this.description = description;
+        }
     }
 
     /**
-     * Lets the taskList of Duke add the task with the given information and
-     * updates content of storage file according to new taskList.
-     * Responses the result to user by using ui of Duke.
-     *
-     * @param tasks   The taskList of Duke.
-     * @param ui      The ui of Duke.
-     * @param storage The storage of Duke.
+     * Constructs an {@code AddCommand} object.
+     */
+    public AddCommand() {
+        super(
+                name,
+                description,
+                usage,
+                Stream.of(SecondaryParam.values()).collect(Collectors.toMap(s -> s.name, s -> s.description))
+        );
+    }
+
+    /**
+     * {@inheritDoc}
      * @throws DukeException If exceptions occur when adding tasks or updating storage.
      */
     @Override
-    public void execute(TaskList tasks, Ui ui, Storage storage) throws DukeException {
+    public void execute(CommandParams commandParams, TaskList tasks, Ui ui, Storage storage) throws DukeException {
         if (commandParams.getMainParam() == null) {
             throw new DukeException("☹ OOPS!!! The description of a task cannot be empty.");
         }
 
         Task taskToAdd;
 
-        switch (commandParams.getCommandType()) {
+        switch (commandParams.getCommandName()) {
         case "todo":
             taskToAdd = new ToDo(commandParams.getMainParam());
-            if (commandParams.containsParams("needs")) {
-                ((ToDo) taskToAdd).setTimeTaken(commandParams.getParam("needs"));
+            if (commandParams.containsParams(SecondaryParam.NEEDS.name)) {
+                ((ToDo) taskToAdd).setTimeTaken(commandParams.getParam(SecondaryParam.NEEDS.name));
             }
             break;
         case "deadline":
-            taskToAdd = new Deadline(commandParams.getMainParam(), commandParams.getParam("by"));
+            taskToAdd = new Deadline(commandParams.getMainParam(), commandParams.getParam(SecondaryParam.BY.name));
             break;
         case "event":
             taskToAdd = new Event(commandParams.getMainParam(),
-                    commandParams.getParam("start"),
-                    commandParams.getParam("end"),
+                    commandParams.getParam(SecondaryParam.START.name),
+                    commandParams.getParam(SecondaryParam.END.name),
                     tasks);
             break;
         default:
             throw new DukeException("☹ OOPS!!! Your command type is unknown!");
         }
 
-        if (commandParams.containsParams("after")) {
-            taskToAdd.setDoAfterDate(commandParams.getParam("after"));
+        if (commandParams.containsParams(SecondaryParam.AFTER.name)) {
+            taskToAdd.setDoAfterDate(commandParams.getParam(SecondaryParam.AFTER.name));
         }
 
-        if (commandParams.containsParams("recurring")) {
-            String recurringType = commandParams.getParam("recurring");
-            taskToAdd.setRecurringType(commandParams.getParam("recurring"));
+        if (commandParams.containsParams(SecondaryParam.RECURRING.name)) {
+            String recurringType = commandParams.getParam(SecondaryParam.RECURRING.name);
+            taskToAdd.setRecurringType(commandParams.getParam(SecondaryParam.RECURRING.name));
         }
-        if (commandParams.containsParams("tentative")) {
+        if (commandParams.containsParams(SecondaryParam.TENTATIVE.name)) {
             taskToAdd.setTentative(true);
         } else {
             taskToAdd.setRecurringType("NONE");

--- a/src/main/java/command/Command.java
+++ b/src/main/java/command/Command.java
@@ -5,45 +5,56 @@ import storage.Storage;
 import task.TaskList;
 import ui.Ui;
 
-/**
- * Represents a command packaged by class {@code Parser}.
- * Works as a parent class of more specified command classes in the package.
- */
-public class Command {
-    protected CommandParams commandParams;
+import java.util.Map;
 
-    /**
-     * Constructs a {@code Command} object with commandType.
-     *
-     * @param commandParams parameters used to invoke the command.
-     */
-    protected Command(CommandParams commandParams) {
-        this.commandParams = commandParams;
+/**
+ * Acts as the parent class of all commands in the command package, with fields meant to be
+ * populated by the individual commands.
+ */
+public abstract class Command {
+    private String name;
+    private String description;
+    private String usage;
+    private Map<String, String> secondaryParams;
+
+    public String getName() {
+        return name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public String getUsage() {
+        return usage;
+    }
+
+    public Map<String, String> getSecondaryParams() {
+        return secondaryParams;
     }
 
     /**
-     * Executes the command.
-     * Works as an empty method of parent class to be overridden.
+     * Creates a new command object, with its name, description, usage and secondary parameters.
      *
+     * @param name the name of the command to create.
+     * @param description the description of the command to create.
+     * @param usage the usage of the command to create.
+     * @param secondaryParams the secondary parameters of the command to create.
+     */
+    public Command(String name, String description, String usage, Map<String, String> secondaryParams) {
+        this.name = name;
+        this.description = description;
+        this.usage = usage;
+        this.secondaryParams = secondaryParams;
+    }
+
+    /**
+     * Executes the command with parameters given by the user.
+     *
+     * @param commandParams the parameters given by the user, parsed into a {@code CommandParams} object.
      * @param tasks The taskList of Duke.
      * @param ui The ui of Duke.
      * @param storage The storage of Duke.
      */
-    public void execute(TaskList tasks, Ui ui, Storage storage) {
-        // to be overridden
-    }
-
-    /**
-     * Returns true if commandType is "exit" and false otherwise.
-     * Decides whether the loop in {@code main} method of Duke terminates.
-     *
-     * @return The boolean indicating whether quit the loop in {@code main} method.
-     */
-    public boolean isExit() {
-        if (commandParams.getCommandType().equals("bye")) {
-            return true;
-        } else {
-            return false;
-        }
-    }
+    public abstract void execute(CommandParams commandParams, TaskList tasks, Ui ui, Storage storage);
 }

--- a/src/main/java/command/Command.java
+++ b/src/main/java/command/Command.java
@@ -41,7 +41,7 @@ public abstract class Command {
      * @param usage the usage of the command to create.
      * @param secondaryParams the secondary parameters of the command to create.
      */
-    public Command(String name, String description, String usage, Map<String, String> secondaryParams) {
+    protected Command(String name, String description, String usage, Map<String, String> secondaryParams) {
         this.name = name;
         this.description = description;
         this.usage = usage;

--- a/src/main/java/command/ConflictCommand.java
+++ b/src/main/java/command/ConflictCommand.java
@@ -12,11 +12,9 @@ public class ConflictCommand extends Command {
 
     /**
      * Constructs a {@code Command} object with commandType.
-     *
-     * @param commandParams parameters used to invoke the command.
      */
-    public ConflictCommand(CommandParams commandParams) {
-        super(commandParams);
+    public ConflictCommand() {
+        super(null, null, null, null);
     }
 
     /**
@@ -27,7 +25,7 @@ public class ConflictCommand extends Command {
      * @throws DukeException If the index given is out of range, invalid, does not exist, or not an Event class.
      */
     @Override
-    public void execute(TaskList taskList, Ui ui, Storage storage) throws DukeException {
+    public void execute(CommandParams commandParams, TaskList taskList, Ui ui, Storage storage) throws DukeException {
         if (commandParams.getMainParam() == null) {
             throw new DukeException("☹ OOPS!!! I don't know which task to search conflicts for!");
         } else {

--- a/src/main/java/command/DeleteCommand.java
+++ b/src/main/java/command/DeleteCommand.java
@@ -16,11 +16,9 @@ public class DeleteCommand extends Command {
     /**
      * Constructs a {@code DeleteCommand} object
      * given the index of the task to be deleted.
-     *
-     * @param commandParams parameters used to invoke the command.
      */
-    public DeleteCommand(CommandParams commandParams) {
-        super(commandParams);
+    public DeleteCommand() {
+        super(null, null, null, null);
     }
 
     /**
@@ -33,8 +31,7 @@ public class DeleteCommand extends Command {
      * @param storage The storage of Duke.
      * @throws DukeException If the index given is out of range, invalid, or does not exist.
      */
-    @Override
-    public void execute(TaskList tasks, Ui ui, Storage storage) throws DukeException {
+    public void execute(CommandParams commandParams, TaskList tasks, Ui ui, Storage storage) throws DukeException {
         if (commandParams.getMainParam() == null) {
             throw new DukeException("☹ OOPS!!! I don't know which task to delete!");
         }

--- a/src/main/java/command/DoneCommand.java
+++ b/src/main/java/command/DoneCommand.java
@@ -16,11 +16,9 @@ public class DoneCommand extends Command {
     /**
      * Constructs a {@code DoneCommand} object
      * given the index of the task to be marked as done.
-     *
-     * @param commandParams parameters used to invoke the command.
      */
-    public DoneCommand(CommandParams commandParams) {
-        super(commandParams);
+    public DoneCommand() {
+        super(null, null, null, null);
     }
 
     /**
@@ -33,8 +31,7 @@ public class DoneCommand extends Command {
      * @param storage The storage of Duke.
      * @throws DukeException If the index given is out of range, invalid, or does not exist.
      */
-    @Override
-    public void execute(TaskList tasks, Ui ui, Storage storage) throws DukeException {
+    public void execute(CommandParams commandParams, TaskList tasks, Ui ui, Storage storage) throws DukeException {
         if (commandParams.getMainParam() == null) {
             throw new DukeException("☹ OOPS!!! I don't know which task to set as done!");
         }

--- a/src/main/java/command/ExitCommand.java
+++ b/src/main/java/command/ExitCommand.java
@@ -13,11 +13,9 @@ import ui.Ui;
 public class ExitCommand extends Command {
     /**
      * Constructs an {@code ExitCommand} object.
-     *
-     * @param commandParams parameters used to invoke the command.
      */
-    public ExitCommand(CommandParams commandParams) {
-        super(commandParams);
+    public ExitCommand() {
+        super(null, null, null, null);
     }
 
     /**
@@ -27,8 +25,7 @@ public class ExitCommand extends Command {
      * @param ui      The ui of Duke.
      * @param storage The storage of Duke.
      */
-    @Override
-    public void execute(TaskList tasks, Ui ui, Storage storage) {
+    public void execute(CommandParams commandParams, TaskList tasks, Ui ui, Storage storage) {
         ui.println("Bye. Hope to see you again soon!");
         System.exit(0);
     }

--- a/src/main/java/command/FindCommand.java
+++ b/src/main/java/command/FindCommand.java
@@ -18,11 +18,9 @@ public class FindCommand extends Command {
     /**
      * Constructs a {@code FindCommand} object
      * with given searched keyword.
-     *
-     * @param commandParams parameters used to invoke the command.
      */
-    public FindCommand(CommandParams commandParams) {
-        super(commandParams);
+    public FindCommand() {
+        super(null, null, null, null);
     }
 
     /**
@@ -34,8 +32,7 @@ public class FindCommand extends Command {
      * @param storage The storage of Duke.
      * @throws DukeException if a search string was not given.
      */
-    @Override
-    public void execute(TaskList tasks, Ui ui, Storage storage) throws DukeException {
+    public void execute(CommandParams commandParams, TaskList tasks, Ui ui, Storage storage) throws DukeException {
         if (commandParams.getMainParam() == null) {
             throw new DukeException("☹ OOPS!!! I don't what to find.");
         }

--- a/src/main/java/command/FreeCommand.java
+++ b/src/main/java/command/FreeCommand.java
@@ -20,11 +20,9 @@ public class FreeCommand extends Command {
 
     /**
      * Constructs a {@code FreeCommand} object with commandType.
-     *
-     * @param commandParams parameters used to invoke the command.
      */
-    public FreeCommand(CommandParams commandParams) {
-        super(commandParams);
+    public FreeCommand() {
+        super(null, null, null, null);
     }
 
     /**
@@ -34,8 +32,7 @@ public class FreeCommand extends Command {
      * @param ui      The ui of Duke.
      * @param storage The storage of Duke.
      */
-    @Override
-    public void execute(TaskList tasks, Ui ui, Storage storage) throws DukeException {
+    public void execute(CommandParams commandParams, TaskList tasks, Ui ui, Storage storage) throws DukeException {
         if (commandParams.getMainParam() == null) {
             throw new DukeException("☹ OOPS!!! I don't know your slot timing");
         }

--- a/src/main/java/command/ListCommand.java
+++ b/src/main/java/command/ListCommand.java
@@ -13,11 +13,9 @@ import ui.Ui;
 public class ListCommand extends Command {
     /**
      * Constructs a {@code ListCommand} object.
-     *
-     * @param commandParams parameters used to invoke the command.
      */
-    public ListCommand(CommandParams commandParams) {
-        super(commandParams);
+    public ListCommand() {
+        super(null, null, null, null);
     }
 
     /**
@@ -27,8 +25,7 @@ public class ListCommand extends Command {
      * @param ui      The ui of Duke.
      * @param storage The storage of Duke.
      */
-    @Override
-    public void execute(TaskList tasks, Ui ui, Storage storage) {
+    public void execute(CommandParams commandParams, TaskList tasks, Ui ui, Storage storage) {
         if (tasks.getSize() == 0) {
             ui.println("Ops, you haven't added any task!");
         } else {

--- a/src/main/java/command/RemindCommand.java
+++ b/src/main/java/command/RemindCommand.java
@@ -15,11 +15,9 @@ import java.util.ArrayList;
 public class RemindCommand extends Command {
     /**
      * Constructs a {@code RemindCommand} object.
-     *
-     * @param commandParams parameters used to invoke the command.
      */
-    public RemindCommand(CommandParams commandParams) {
-        super(commandParams);
+    public RemindCommand() {
+        super(null, null, null, null);
     }
 
     /**
@@ -29,8 +27,7 @@ public class RemindCommand extends Command {
      * @param ui      The ui of Duke.
      * @param storage The storage of Duke.
      */
-    @Override
-    public void execute(TaskList tasks, Ui ui, Storage storage) {
+    public void execute(CommandParams commandParams, TaskList tasks, Ui ui, Storage storage) {
         int count = 0;
         ArrayList<String> toPrint = new ArrayList<>();
         for (int i = 0; i < tasks.getSize(); i++) {

--- a/src/main/java/command/RescheduleCommand.java
+++ b/src/main/java/command/RescheduleCommand.java
@@ -8,8 +8,8 @@ import ui.Ui;
 
 public class RescheduleCommand extends Command {
 
-    public RescheduleCommand(CommandParams commandParams) {
-        super(commandParams);
+    public RescheduleCommand() {
+        super(null, null, null, null);
     }
 
     /**
@@ -20,8 +20,7 @@ public class RescheduleCommand extends Command {
      * @param storage The storage of Duke.
      * @throws DukeException if the task cannot be found, or does not contain
      */
-    @Override
-    public void execute(TaskList tasks, Ui ui, Storage storage) throws DukeException {
+    public void execute(CommandParams commandParams, TaskList tasks, Ui ui, Storage storage) throws DukeException {
         if (commandParams.getMainParam() == null) {
             throw new DukeException("☹ OOPS!!! I don't know which task to reschedule!");
         }

--- a/src/main/java/command/ScheduleCommand.java
+++ b/src/main/java/command/ScheduleCommand.java
@@ -19,11 +19,9 @@ public class ScheduleCommand extends Command {
 
     /**
      * Constructs a {@code Command} object with commandType.
-     *
-     * @param commandParams parameters used to invoke the command.
      */
-    public ScheduleCommand(CommandParams commandParams) {
-        super(commandParams);
+    public ScheduleCommand() {
+        super(null, null, null, null);
     }
 
     /**
@@ -32,8 +30,7 @@ public class ScheduleCommand extends Command {
      * @param ui      The ui of Duke.
      * @param storage The storage of Duke.
      */
-    @Override
-    public void execute(TaskList tasks, Ui ui, Storage storage) throws DukeException {
+    public void execute(CommandParams commandParams, TaskList tasks, Ui ui, Storage storage) throws DukeException {
         if (commandParams.getMainParam() == null) {
             throw new DukeException("☹ OOPS!!! I don't which day's schedule to display.");
         }

--- a/src/main/java/parser/CommandParams.java
+++ b/src/main/java/parser/CommandParams.java
@@ -11,10 +11,10 @@ import java.util.Map;
  */
 public class CommandParams {
     // Internal map that stores all secondary parameters
-    private Map<String, String> paramMap;
+    private Map<String, String> secondaryParams;
 
     // The command type i.e. the first word in the command
-    private String commandType;
+    private String commandName;
 
     // The main parameter value i.e. everything after the first word, before any secondary parameters are declared
     private String mainParam;
@@ -39,14 +39,14 @@ public class CommandParams {
      * @throws DukeException if the user specified a parameter twice.
      */
     public CommandParams(String fullCommand) throws DukeException {
-        paramMap = new HashMap<String, String>();
+        secondaryParams = new HashMap<String, String>();
 
         // Split the input into an array of Strings, containing concatenated parameter names and values
         String[] nameValueStrings = PARAM_INDICATOR_REGEX.split(fullCommand);
 
         // Get commandType and mainParam first
         String[] typeAndMainParam = SPACE_REGEX.split(nameValueStrings[0], 2);
-        commandType = typeAndMainParam[0];
+        commandName = typeAndMainParam[0];
         if (typeAndMainParam.length == 2) { // has main param
             mainParam = typeAndMainParam[1];
         } else {
@@ -56,14 +56,14 @@ public class CommandParams {
         // Get all the others
         for (int i = 1; i < nameValueStrings.length; i++) {
             String[] nameValuePair = SPACE_REGEX.split(nameValueStrings[i], 2);
-            if (paramMap.containsKey(nameValuePair[0])) { // can't contain the same key twice
+            if (secondaryParams.containsKey(nameValuePair[0])) { // can't contain the same key twice
                 throw new DukeException(String.format("☹ OOPS!!! You specified %1$s twice!", nameValuePair[0]));
             }
 
             if (nameValuePair.length == 2) {
-                paramMap.put(nameValuePair[0], nameValuePair[1]);
+                secondaryParams.put(nameValuePair[0], nameValuePair[1]);
             } else {
-                paramMap.put(nameValuePair[0], null);
+                secondaryParams.put(nameValuePair[0], null);
             }
         }
     }
@@ -73,8 +73,8 @@ public class CommandParams {
      *
      * @return {@code commandType}.
      */
-    public String getCommandType() {
-        return commandType;
+    public String getCommandName() {
+        return commandName;
     }
 
     /**
@@ -95,7 +95,7 @@ public class CommandParams {
      * @throws DukeException if the parameter does not exist, or is null.
      */
     public String getParam(String paramName) throws DukeException {
-        String paramValue = paramMap.get(paramName);
+        String paramValue = secondaryParams.get(paramName);
         if (paramValue == null) {
             throw new DukeException(String.format("☹ OOPS!!! You need to give me a value for %1$s!", paramName));
         } else {
@@ -111,7 +111,7 @@ public class CommandParams {
      * @return the value of the requested parameter. May be null.
      */
     public String getOptionalParam(String paramName) {
-        return paramMap.get(paramName);
+        return secondaryParams.get(paramName);
     }
 
     /**
@@ -125,7 +125,7 @@ public class CommandParams {
      */
     public boolean containsParams(String... paramNames) {
         for (String paramName : paramNames) {
-            if (!paramMap.containsKey(paramName)) {
+            if (!secondaryParams.containsKey(paramName)) {
                 return false;
             }
         }

--- a/src/main/java/parser/Parser.java
+++ b/src/main/java/parser/Parser.java
@@ -22,55 +22,51 @@ import exception.DukeException;
 public class Parser {
 
     /**
-     * Converts the {@code String} fullCommand into {@code Command} object.
-     * Returns the {@code Command} object.
+     * Returns the command with the name commandName.
      *
-     * @param fullCommand The command line read from user input.
+     * @param commandName The name of the command.
      * @return {@code Command} object converted from fullCommand.
      * @throws DukeException If user input is invalid.
      */
-    public static Command parse(String fullCommand) throws DukeException {
-        CommandParams commandParams = new CommandParams(fullCommand);
-
-        switch (commandParams.getCommandType()) {
+    public static Command getCommand(String commandName) throws DukeException {
+        switch (commandName) {
         case "todo":
         case "deadline":
         case "event":
-            return new AddCommand(commandParams);
+            return new AddCommand();
 
         case "list":
-            return new ListCommand(commandParams);
+            return new ListCommand();
 
         case "done":
-            return new DoneCommand(commandParams);
+            return new DoneCommand();
 
         case "delete":
-            return new DeleteCommand(commandParams);
+            return new DeleteCommand();
 
         case "find":
-            return new FindCommand(commandParams);
+            return new FindCommand();
 
         case "bye":
-            return new ExitCommand(commandParams);
+            return new ExitCommand();
 
         case "schedule":
-            return new ScheduleCommand(commandParams);
+            return new ScheduleCommand();
 
         case "remind":
-            return new RemindCommand(commandParams);
+            return new RemindCommand();
 
         case "reschedule":
-            return new RescheduleCommand(commandParams);
+            return new RescheduleCommand();
 
         case "free":
-            return new FreeCommand(commandParams);
+            return new FreeCommand();
 
         case "conflict":
-            return new ConflictCommand(commandParams);
+            return new ConflictCommand();
 
         default:
             throw new DukeException("☹ OOPS!!! I don't know what that means :-(");
         }
-
     }
 }

--- a/src/test/java/parser/CommandParamsTest.java
+++ b/src/test/java/parser/CommandParamsTest.java
@@ -16,7 +16,7 @@ public class CommandParamsTest {
     @Test
     public void testCorrectParamValues() {
         CommandParams testParams = new CommandParams("name description goes here /a is a /b is b /c is c");
-        assertEquals(testParams.getCommandType(), "name");
+        assertEquals(testParams.getCommandName(), "name");
         assertEquals(testParams.getMainParam(), "description goes here");
         assertEquals(testParams.getParam("a"), "is a");
         assertEquals(testParams.getOptionalParam("a"), "is a");


### PR DESCRIPTION
I changed the structure of the `Command` class greatly, with small modifications to the `Parser` class and `Duke` class which will be expanded on in later refactors. The changes to command are primarily done to increase its compatability with a future Help command, and to improve maintanability within the command classes by removing the "magic strings" used to access secondary parameters from the `CommandParams` object. 

Firstly, the class was converted to an abstract class, removing the need to override the execute command; as `Command` itself is not meant to be constructed, only its subclasses, this change also makes that intention more clear.

The `CommandParams` object used to execute the command is no longer stored by the `Command` object. I made this decision as its storage does not improve functionality of the `Command` objects. On the other hand, previously, no information about the command's name, description, usage or secondary parameters was stored within it. Now, these can be accessed from `Command` using getters; the fields themselves are private to preserve immutability, as these fields should not be changed. 

The individual commands should now declare their constant fields at the start of their declaration, and pass them to the `super()` (see `AddCommand`, the others have only been updated for compatibility with the new code, rather than with the correct values). 

While the name, description and usages are strings, the secondary parameters should be stored within the class as an enum, grouping them together while reducing the amount of magic numbers and "magic strings" in the code. Unfortunately, there is no way to "inherit" enums; the enum fields and constructor will have to be declared in every subclass of `Command`, which is less than ideal. As enums are final by default, the parent class stores the secondary parameter information in a `Map<String, String>` instead. The enum has to be converted before being passed: 
```java
Stream.of(SecondaryParam.values()).collect(Collectors.toMap(s -> s.name, s -> s.description))
```

`Parser` got a minor change, with the `parse` method changing to a `getCommand` method. This allows the caller to access methods of the command with only its name. 

With these changes, all instances of `commandType` have been changed to `commandName` or `name` within the commands themselves, and all references to the secondary parameters have been changed to refer to them as some variant of `secondaryParams`. 