### PR TITLE
DeleteCommand 

### DIFF
--- a/src/main/java/duke/command/DeleteCommand.java
+++ b/src/main/java/duke/command/DeleteCommand.java
@@ -31,6 +31,11 @@ public class DeleteCommand extends Command {
      * @throws DukeException If the index given is out of range, invalid, or does not exist.
      */
     public void execute(CommandParams commandParams, ExpenseList expensesList, Ui ui) throws DukeException {
+        if (!commandParams.containsMainParam()) {
+            throw new DukeException(String.format(DukeException.MESSAGE_COMMAND_PARAM_MISSING, "index"));
+        }
+        expensesList.remove(Integer.parseInt(commandParams.getMainParam()));
+        expensesList.update();
 
     }
 }

--- a/src/main/java/duke/command/DeleteCommand.java
+++ b/src/main/java/duke/command/DeleteCommand.java
@@ -8,7 +8,7 @@ import duke.ui.Ui;
 
 /**
  * Represents a specified command as DeleteCommand by extending the {@code Command} class.
- * Deletes the task with given index from the ExpenseList of Duke.
+ * Deletes the task with given index or specific command from the ExpenseList of Duke.
  * Responses with the result.
  */
 public class DeleteCommand extends Command {
@@ -22,7 +22,7 @@ public class DeleteCommand extends Command {
     }
 
     /**
-     * Lets the ExpenseList of Duke delete the task with the given index and
+     * Lets the ExpenseList of Duke delete the task with the given index(s), or the entire task list and
      * updates content of storage file according to new ExpenseList.
      * Responses the result to user by using ui of Duke.
      *
@@ -34,8 +34,20 @@ public class DeleteCommand extends Command {
         if (!commandParams.containsMainParam()) {
             throw new DukeException(String.format(DukeException.MESSAGE_COMMAND_PARAM_MISSING, "index"));
         }
-        expensesList.remove(Integer.parseInt(commandParams.getMainParam()));
-        expensesList.update();
 
+        if (commandParams.getMainParam().equals("all")) {
+            expensesList.clear();
+        } else if (commandParams.getMainParam().contains("-")) {
+            String[] index = commandParams.getMainParam().split("-");
+            int difference = Integer.parseInt(index[1])-Integer.parseInt(index[0]);
+            int counter = 0;
+                for (int i = Integer.parseInt(index[0]); counter <= difference; counter++) {
+                    expensesList.remove(i);
+                }
+            }
+        else {
+            expensesList.remove(Integer.parseInt(commandParams.getMainParam()));
+        }
+        expensesList.update();
     }
 }

--- a/src/main/java/duke/dukeobject/DukeList.java
+++ b/src/main/java/duke/dukeobject/DukeList.java
@@ -128,6 +128,13 @@ abstract class DukeList<T extends DukeItem> {
     }
 
     /**
+     * Removes all items from {@code internalList}.
+     */
+    public void clear() {
+        internalList.clear();
+    }
+
+    /**
      * Calling this method indicates that {@code internalList} or one of its members has changed,
      * that the file should be updated, and that the state has progressed such that all {@code redoStates}
      * are now invalid and should be discarded.


### PR DESCRIPTION
DeleteCommand for internalList only for now, as the implementation for externalList (e.g. view format) has yet to be completed. 

Three variations to the deleteCommand:
`delete all` : deletes all expenses from expenseList (i.e. internalList)
`delete index`: deletes the specific expense as shown in expenseList according to the index
`delete index1 - index2`: deletes the range of expenses as shown in expenseList according to the indexes 